### PR TITLE
✨[feat]: 로그인 페이지

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,8 @@ import { Route, Routes, BrowserRouter as Router } from "react-router-dom";
 import { LAYOUT_ROUTES } from "./routes/layoutRouter";
 import ReactDOM from "react-dom"; 
 import MainLayout from "./stories/template/common/MainLayout";
+import { NOT_LAYOUT_ROUTES } from "./routes/notLayoutRouter";
+import NoFooterLayout from "./stories/template/common/NoFooterLayout";
 
 function App() {
   return (
@@ -13,6 +15,14 @@ function App() {
             <Route key={route.name} path={route.path()} element={<route.component />} />
           )
         })}
+        </Route>
+
+        <Route element={<NoFooterLayout />}>
+          {NOT_LAYOUT_ROUTES.map((route) => {
+            return (
+              <Route key={route.name} path={route.path()} element={<route.component />} />
+            )
+          })}
         </Route>
       </Routes>
     </Router>

--- a/src/hooks/useValid.ts
+++ b/src/hooks/useValid.ts
@@ -1,0 +1,71 @@
+import { useEffect, useState } from "react";
+
+type TValid = {
+  email: string,
+  password: string,
+  code?: number,
+  name?: string,
+  repassword?: string
+}
+
+const useValid = (changeValue: TValid) => {
+  console.log(changeValue, '현재 벨류')
+  const [validText, setValidText] = useState({
+    email: '',
+    password: '',
+    repassword: '',
+    code: '',
+    name: '',
+  });
+  const [isValid, setIsValid] = useState({
+    isEmail: false,
+    isPassword: false,
+    isName: false,
+    isCode: false,
+    isPasswordConfirm: false,
+  })
+
+  // 이메일 형식 유효성 체크
+  const validateEmail = (email: string) => {
+    const exp = /^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,4}$/;
+    return exp.test(email);
+  };
+
+  // 비밀번호 형식 유효성 체크
+  // 6자 이상, 대소문자를 구분하지 않으며, 특수문자 하나이상 포함
+  const validatePassword = (password: string) => {
+    const exp = /^(?=.*[a-zA-Z0-9])(?=.*[!@#$%^&*])[A-Za-z0-9!@#$%^&*]{6,}$/i;
+    return exp.test(password);
+  };
+
+  // 이름 형식 유효성 체크
+  // 숫자, 특수문자 x
+  const validateName = (name: string) => {
+    const exp = /^[A-Za-z]+$/i;
+    return exp.test(name);
+  };
+
+  useEffect(() => {
+    setValidText({
+      ...validText,
+      email: changeValue.email? (validateEmail(changeValue.email)? '' : '이메일 형식이 올바르지 않습니다.'):'',
+      password: changeValue.password? (validatePassword(changeValue.password) ? '' : '비밀번호 형식이 올바르지 않습니다.'):'',
+      repassword: changeValue.repassword? (changeValue.password === changeValue.repassword ? '' : '비밀번호가 일치하지 않습니다.'): '',
+      name: changeValue.name ? (validateName(changeValue.name) ? '' : '특수문자와 숫자를 제외한 실명을 입력해주세요.'): '',
+    });
+
+    setIsValid({
+      isEmail: validateEmail(changeValue.email),
+      isPassword: validatePassword(changeValue.password),
+      isName:  changeValue.name ? validateName(changeValue.name) : true,
+      isCode: false,
+      isPasswordConfirm: changeValue.password === changeValue.repassword,
+    });
+  }, [changeValue]);
+
+  // TODO: 서버에서 받은 code와 사용자입력 code가 같은지 체크하는 유효성 로직
+
+  return { validText, isValid };
+}
+
+export default useValid;

--- a/src/routes/layoutRouter.ts
+++ b/src/routes/layoutRouter.ts
@@ -6,7 +6,7 @@ export const LAYOUT_ROUTES_URLS = {
     name: "몽타주 공개 페이지",
     path: () => '/',
     component: MontagePublicPage,
-  }
+  },
 } as const;
 
 export const LAYOUT_ROUTES: TRoute[] = Object.values(LAYOUT_ROUTES_URLS);

--- a/src/routes/notLayoutRouter.ts
+++ b/src/routes/notLayoutRouter.ts
@@ -1,0 +1,12 @@
+import LoginPage from "../stories/pages/login/LoginPage";
+import { TRoute } from "../types/commonTypes";
+
+export const NOT_LAYOUT_ROUTES_URLS = {
+  loginPage: {
+    name: "로그인 페이지",
+    path: () => '/login',
+    component: LoginPage,
+  }
+} as const;
+
+export const NOT_LAYOUT_ROUTES: TRoute[] = Object.values(NOT_LAYOUT_ROUTES_URLS);

--- a/src/stories/atoms/longBtn/index.tsx
+++ b/src/stories/atoms/longBtn/index.tsx
@@ -1,11 +1,12 @@
 export type TLongBtn = {
   text: string;
-  activate?: boolean;
+  activate: boolean;
+  onClick: () => void;
 }
 
-const LongBtn = ({ text, activate }: TLongBtn) => {
+const LongBtn = ({ text, activate, onClick }: TLongBtn) => {
   return (
-    <button className={`rounded-17 font-semibold text-center text-white py-16 px-175 ${activate ? 'bg-mainColor ' : 'bg-superSubColor'}`}>{text}</button>
+    <button onClick={onClick} disabled={activate? false : true} className={`rounded-17 font-semibold text-center text-white py-14 w-full ${activate ? 'bg-mainColor' : 'bg-superSubColor'}` }>{text}</button>
   );
 }
 

--- a/src/stories/molecules/longfield/index.stories.tsx
+++ b/src/stories/molecules/longfield/index.stories.tsx
@@ -13,6 +13,6 @@ type Story = StoryObj<typeof Longfield>;
 export const Primary: Story = {
   args: {
     label: '이메일',
-    placeholder: '대소문자 구분 없이 6자 이상, 특수문자 포함'
+    placeholder: '대소문자 구분 없이 6자 이상, 특수문자 포함',
   },
 };

--- a/src/stories/molecules/longfield/index.tsx
+++ b/src/stories/molecules/longfield/index.tsx
@@ -1,13 +1,15 @@
 export type TField = {
-  label?: string;
+  label: string;
   placeholder?: string;
+  type: string;
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
 }
 
-const Longfield = ({label, placeholder}: TField) => {
+const Longfield = ({label, placeholder, type, onChange}: TField) => {
   return (
     <div className="flex flex-col gap-2 w-full max-w-400">
       <label>{label}</label>
-      <input placeholder={placeholder} className="border-2 border-superSubColor rounded-12 px-14 py-13"></input>
+      <input onChange={onChange} placeholder={placeholder} type={type} className="border-2 border-superSubColor rounded-12 px-14 py-10"></input>
     </div>
   );
 }

--- a/src/stories/molecules/shortfield/index.tsx
+++ b/src/stories/molecules/shortfield/index.tsx
@@ -4,7 +4,7 @@ const Shortfield = ({label, placeholder}: TField) => {
   return (
     <div className="flex flex-col gap-2 w-full max-w-305">
       <label>{label}</label>
-      <input placeholder={placeholder} className="border-2 border-superSubColor rounded-12 px-14 py-13"></input>
+      <input placeholder={placeholder} className="border-2 border-superSubColor rounded-12 px-14 py-10"></input>
     </div>
   );
 }

--- a/src/stories/pages/login/LoginPage.tsx
+++ b/src/stories/pages/login/LoginPage.tsx
@@ -1,0 +1,41 @@
+import { useEffect, useState } from "react";
+import useValid from "../../../hooks/useValid";
+import LongBtn from "../../atoms/longBtn";
+import Title from "../../atoms/title";
+import Longfield from "../../molecules/longfield";
+import ErrorMsg from "../../atoms/errorMsg";
+
+const LoginPage = () => {
+
+  const [form, setForm] = useState({
+    email: '',
+    password: '',
+  })
+  const { validText, isValid } = useValid(form);
+  const [error, setError] = useState(false);
+
+  useEffect(() => {
+    if (!form.email || !form.password) {
+      setError(false)
+    }
+  }, [form])
+
+  const handleClick = () => {
+    setError(!isValid.isEmail || !isValid.isPassword);
+  }
+
+  return(
+    <div className="flex justify-center mt-115">
+      <form className="w-full max-w-480 rounded-20 bg-white px-40 py-40" onSubmit={(e) => e.preventDefault()}>
+        <Title text="로그인하기" />
+        <div className={'mt-30 hidden'+( error? (isValid.isEmail && isValid.isPassword ? '': 'block '): ((!isValid.isEmail || !isValid.isPassword) ? ' block':''))}><ErrorMsg text={validText.email || validText.password} /></div>
+        <div className="mt-30"><Longfield label="이메일" type="email" placeholder="example@gmail.com" onChange={e => setForm({...form, email:e.target.value})} /></div>
+        <div className="mt-10"><Longfield label="비밀번호" type="password" placeholder="대소문자 구분 없이 6자 이상, 특수문자 포함" onChange={e => setForm({...form, password:e.target.value})} /></div>
+        <div className="mt-50"><LongBtn text="로그인" onClick={handleClick} activate={form.email && form.password? true: false} /></div>
+        <div className="mt-12 gap-2 text-14 text-center">회원이 아니신가요? <a href="/join" className="text-14 font-semibold">가입하기</a></div>
+      </form>
+    </div>
+  )
+}
+
+export default LoginPage;

--- a/src/stories/template/common/NoFooterLayout.tsx
+++ b/src/stories/template/common/NoFooterLayout.tsx
@@ -1,0 +1,13 @@
+import Header from "../../molecules/header"
+import { Outlet } from "react-router-dom";
+
+const NoFooterLayout = () => {
+  return (
+    <div className="max-w-1440 min-h-100vh flex flex-col">
+      <Header />
+      <div className="flex flex-col flex-grow px-40 bg-mainColor pt-10 pb-50 h-screen"><Outlet /></div>
+    </div>
+  )
+}
+
+export default NoFooterLayout


### PR DESCRIPTION
### PR Type

- [x] 기능 개발 (Feature)
- [x] 화면 작업 (Style, CSS)

## 작업 내용

- ‼️ 이슈에서 확인 가능
- [x] NoFooter layout 만들기
- [x] 입력여부에 따른 버튼 활성화
- [x] 이메일, 비밀번호 형식 validation hook
- [x] 케이스에 따른 경고 메세지 hidden/block 처리
- [x] 로그인 페이지 완성

## Before

## After

- 첫 렌더링 화면 (값을 입력하지 않았을 경우, 버튼 비활성화)
<img width="1122" alt="스크린샷 2023-11-05 오후 9 25 56" src="https://github.com/Catch-You/CatchYou-Frontend/assets/69382168/61d1ed95-078d-4bf7-a5c7-2f21f18a9c0a">


- 로그인 버튼 클릭시 validation에 따른 에러 컴포넌트 block/hidden
- validation이 통과되더라도, 유효성에 어긋나도록 값을 변경하면 에러 컴포넌트 block
<img width="1126" alt="스크린샷 2023-11-05 오후 9 26 17" src="https://github.com/Catch-You/CatchYou-Frontend/assets/69382168/e0be6c21-04fe-4431-887e-e44311a4aecf">


- validation 에러가 난 상태에서, 값을 전부 지웠을 때 에러 컴포넌트 hidden, 버튼 비활성화
<img width="1127" alt="스크린샷 2023-11-05 오후 9 26 23" src="https://github.com/Catch-You/CatchYou-Frontend/assets/69382168/d5d30dc6-a1a8-4c98-ad73-7f80576c6bd9">


## 참고 사항, 첨부 자료 등