### PR TITLE
✨[feat]: 마이페이지 레이아웃, 테이블 컴포넌트

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,8 @@ import ReactDOM from "react-dom";
 import MainLayout from "./stories/template/common/MainLayout";
 import { NOT_LAYOUT_ROUTES } from "./routes/notLayoutRouter";
 import NoFooterLayout from "./stories/template/common/NoFooterLayout";
+import MypageLayout from "./stories/template/common/MypageLayout";
+import { MYPAGE_ROUTES } from "./routes/mypageRouter";
 
 function App() {
   return (
@@ -19,6 +21,13 @@ function App() {
 
         <Route element={<NoFooterLayout />}>
           {NOT_LAYOUT_ROUTES.map((route) => {
+            return (
+              <Route key={route.name} path={route.path()} element={<route.component />} />
+            )
+          })}
+        </Route>
+        <Route element={<MypageLayout />}>
+          {MYPAGE_ROUTES.map((route) => {
             return (
               <Route key={route.name} path={route.path()} element={<route.component />} />
             )

--- a/src/routes/mypageRouter.ts
+++ b/src/routes/mypageRouter.ts
@@ -1,0 +1,12 @@
+import MyPage from "../stories/pages/my/MyPage";
+import { TRoute } from "../types/commonTypes";
+
+export const MYPAGE_ROUTES_URLS = {
+  mypage: {
+    name: "마이페이지",
+    path: () => '/mypage',
+    component: MyPage,
+  },
+} as const;
+
+export const MYPAGE_ROUTES: TRoute[] = Object.values(MYPAGE_ROUTES_URLS);

--- a/src/routes/notLayoutRouter.ts
+++ b/src/routes/notLayoutRouter.ts
@@ -1,3 +1,4 @@
+import EnterCodePage from "../stories/pages/enterCode/EnterCodePage";
 import LoginPage from "../stories/pages/login/LoginPage";
 import SignMemberPage from "../stories/pages/sign/SignMemberPage";
 import SignPage from "../stories/pages/sign/SignPage";
@@ -19,6 +20,11 @@ export const NOT_LAYOUT_ROUTES_URLS = {
     path: () => '/join',
     component: SignPage,
   },
+  enterCodePage: {
+    name: "사건코드 입력 페이지",
+    path: () => '/incidentCode',
+    component: EnterCodePage,
+  }
 } as const;
 
 export const NOT_LAYOUT_ROUTES: TRoute[] = Object.values(NOT_LAYOUT_ROUTES_URLS);

--- a/src/routes/notLayoutRouter.ts
+++ b/src/routes/notLayoutRouter.ts
@@ -1,4 +1,5 @@
 import LoginPage from "../stories/pages/login/LoginPage";
+import SignMemberPage from "../stories/pages/sign/SignMemberPage";
 import SignPage from "../stories/pages/sign/SignPage";
 import { TRoute } from "../types/commonTypes";
 
@@ -8,11 +9,16 @@ export const NOT_LAYOUT_ROUTES_URLS = {
     path: () => '/login',
     component: LoginPage,
   },
+  signMemberPage: {
+    name: "회원 분류 페이지",
+    path: () => '/member',
+    component: SignMemberPage,
+  },
   signPage: {
     name: "회원가입 페이지",
     path: () => '/join',
     component: SignPage,
-  }
+  },
 } as const;
 
 export const NOT_LAYOUT_ROUTES: TRoute[] = Object.values(NOT_LAYOUT_ROUTES_URLS);

--- a/src/routes/notLayoutRouter.ts
+++ b/src/routes/notLayoutRouter.ts
@@ -1,3 +1,4 @@
+import CaseRegistPage from "../stories/pages/caseRegist/CaseRegistPage";
 import EnterCodePage from "../stories/pages/enterCode/EnterCodePage";
 import LoginPage from "../stories/pages/login/LoginPage";
 import SignMemberPage from "../stories/pages/sign/SignMemberPage";
@@ -24,6 +25,11 @@ export const NOT_LAYOUT_ROUTES_URLS = {
     name: "사건코드 입력 페이지",
     path: () => '/incidentCode',
     component: EnterCodePage,
+  },
+  caseRegisterPage: {
+    name: "사건 등록 페이지",
+    path: () => '/registerCase',
+    component: CaseRegistPage,
   }
 } as const;
 

--- a/src/routes/notLayoutRouter.ts
+++ b/src/routes/notLayoutRouter.ts
@@ -1,3 +1,4 @@
+import CaseDetailPage from "../stories/pages/caseDetail/CaseDetailPage";
 import CaseRegistPage from "../stories/pages/caseRegist/CaseRegistPage";
 import EnterCodePage from "../stories/pages/enterCode/EnterCodePage";
 import LoginPage from "../stories/pages/login/LoginPage";
@@ -30,7 +31,12 @@ export const NOT_LAYOUT_ROUTES_URLS = {
     name: "사건 등록 페이지",
     path: () => '/registerCase',
     component: CaseRegistPage,
-  }
+  },
+  caseDetailPage: {
+    name: "사건 상세 페이지",
+    path: (id = ":id") => `/${id}`,
+    component: CaseDetailPage,
+  },
 } as const;
 
 export const NOT_LAYOUT_ROUTES: TRoute[] = Object.values(NOT_LAYOUT_ROUTES_URLS);

--- a/src/stories/atoms/infoCard/index.stories.tsx
+++ b/src/stories/atoms/infoCard/index.stories.tsx
@@ -13,6 +13,7 @@ type Story = StoryObj<typeof InfoCard>;
 export const Primary: Story = {
   args: {
     name: '홍길동',
-    imgSrc: 'https://blogpfthumb-phinf.pstatic.net/MjAyMzA4MTVfMjgx/MDAxNjkyMDM0MjE3MzQ4._BVCNU9m5pBQ6jQzxHRkRwNtiuKck6RwevKeji6AcmMg.mCqu36OBQR7mHkS4uKd7_9hFOCo7JqkwpPWiFICjhucg.JPEG.myday0827/IMG_0137.jpg/IMG_0137.jpg?type=w161'
+    imgSrc: 'https://blogpfthumb-phinf.pstatic.net/MjAyMzA4MTVfMjgx/MDAxNjkyMDM0MjE3MzQ4._BVCNU9m5pBQ6jQzxHRkRwNtiuKck6RwevKeji6AcmMg.mCqu36OBQR7mHkS4uKd7_9hFOCo7JqkwpPWiFICjhucg.JPEG.myday0827/IMG_0137.jpg/IMG_0137.jpg?type=w161',
+    id: 1
   },
 };

--- a/src/stories/atoms/infoCard/index.tsx
+++ b/src/stories/atoms/infoCard/index.tsx
@@ -1,12 +1,19 @@
+import { useNavigate } from "react-router-dom";
+
 type TInfoCard = {
   name: string;
   age?: number;
   imgSrc: string;
+  id: number;
 }
 
-const InfoCard = ({name, age, imgSrc}: TInfoCard) => {
+const InfoCard = ({name, age, imgSrc, id}: TInfoCard) => {
+  const navigate = useNavigate();
+  const handleClick = ()  => {
+    navigate(`/${id}`)
+  }
   return (
-    <div className="h-240 w-190 rounded-lg bg-white flex flex-col">
+    <div className="h-240 w-190 rounded-lg bg-white flex flex-col" onClick={handleClick}>
       <img className="rounded-t-lg" src={imgSrc} width={230} height={200} />
       <div className="text-center text-16 pt-10">{name} / {age? `${age}`: '?'}세</div>
     </div>

--- a/src/stories/atoms/table/index.stories.tsx
+++ b/src/stories/atoms/table/index.stories.tsx
@@ -1,0 +1,30 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import  Table  from '.';
+
+const meta: Meta<typeof Table> = {
+  title: 'atoms/Table',
+  component: Table,
+  tags: ["autodocs"],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Table>;
+
+export const Primary: Story = {
+  args: {
+    title: ['사건번호', '공개여부', '몽타주'],
+    data: [
+      {
+        no: '2023고단454',
+        public: true,
+        montage: 'https://sdfsdf//12234/23dsjfkdfsdf',
+      },
+      {
+        no: '2013고단254',
+        public: false,
+        montage: 'https://sdfsdf//4234/11dsjfkd',
+      },   
+    ]
+  },
+};

--- a/src/stories/atoms/table/index.tsx
+++ b/src/stories/atoms/table/index.tsx
@@ -1,0 +1,39 @@
+import { caseList } from "../../../types/case/caseList";
+
+type TTable = {
+  title: string[],
+  data: caseList[],
+}
+
+const Table = ({title, data}: TTable) => {
+  return (
+    <table className="table-fixed w-full border-separate rounded-12 overflow-hidden">
+    <thead className="bg-superSubColor h-45">
+      <tr>
+        {title.map((item, index) => (
+          <th key={`${item}+${index}`}>
+            {item}
+          </th>
+        ))}
+      </tr>
+    </thead>
+    <tbody className="bg-gray-50">
+        {data.map((item, index) => (
+          <tr>
+            <td className="px-12 py-14 text-center text-mainColor text-15" key={`${item}+${index}`}>
+              {item.no}
+            </td>
+            <td className="px-12 py-14 text-center text-mainColor text-15" key={`${item}+${index}`}>
+              {item.public? '공개' : '비공개'}
+            </td>
+            <td className="px-12 py-14 text-center text-mainColor text-15" key={`${item}+${index}`}>
+              {item.montage}
+            </td>
+          </tr>
+        ))}
+    </tbody>
+  </table>
+  )
+}
+
+export default Table;

--- a/src/stories/molecules/longfield/index.tsx
+++ b/src/stories/molecules/longfield/index.tsx
@@ -1,5 +1,5 @@
 export type TField = {
-  label: string;
+  label?: string;
   placeholder?: string;
   type: string;
   onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;

--- a/src/stories/molecules/selector/index.stories.tsx
+++ b/src/stories/molecules/selector/index.stories.tsx
@@ -1,0 +1,18 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import  Selector  from '.';
+
+const meta: Meta<typeof Selector> = {
+  title: 'molecules/Selector',
+  component: Selector,
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof Selector>;
+
+export const Primary: Story = {
+  args: {
+    text: "사건 공개범위를 선택하세요.",
+    options: ["비공개", "공개"],
+  },
+};

--- a/src/stories/molecules/selector/index.tsx
+++ b/src/stories/molecules/selector/index.tsx
@@ -1,0 +1,60 @@
+import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
+import { useState } from 'react';
+
+type TSelector = {
+  text: string;
+  options: string[];
+}
+
+const Selector = ({text, options}: TSelector) => {
+
+  const [isOpen, setIsOpen] = useState(false);
+  const [selectedOption, setSelectedOption] = useState<string>('');
+
+  const handleToggle = () => {
+    setIsOpen((prev) => !prev);
+  };
+
+  const handleOptionSelect = (option: string) => {
+    setSelectedOption(option);
+    setIsOpen(false);
+  };
+
+  const handleSelectClick = (e: React.MouseEvent<HTMLSelectElement>) => {
+    e.preventDefault(); // 시스템 기본 동작 막기
+    handleToggle(); // 드롭다운 토글
+  };
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div>{text}</div>
+      <div className='relative'>
+        <select value={selectedOption} className="w-full max-w-193 rounded-12 border-2 border-superSubColor px-14 py-10 appearance-none" onClick={handleSelectClick} onChange={(e) => setSelectedOption(e.target.value)} >
+          <option value="">
+            {selectedOption ? selectedOption : '옵션을 선택하세요'}
+          </option>
+        </select>
+        <span className='absolute top-1/4 start-40 text-superSubColor cursor-pointer' onClick={handleToggle}><KeyboardArrowDownIcon /></span>
+        
+        {isOpen && (
+          <div className="absolute top-full left-0 z-10 w-full max-w-193 rounded-12 border-2 border-superSubColor mt-1">
+          
+            {options.map((item, index) => (
+              <option
+                key={`${item}+${index}`}
+                value={item}
+                className="px-10 py-6 cursor-pointer hover:bg-gray-200"
+                onClick={() => handleOptionSelect(item)}
+              >
+                {item}
+              </option>
+            ))}
+          </div>
+        )}
+      </div>
+      
+    </div>
+  )
+}
+
+export default Selector;

--- a/src/stories/molecules/selector/index.tsx
+++ b/src/stories/molecules/selector/index.tsx
@@ -1,24 +1,13 @@
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 import { Dispatch, SetStateAction, useState } from 'react';
+import { TCaseForm } from '../../pages/caseRegist/CaseRegistPage';
 
 type TSelector = {
   text: string;
   options: string[];
   type: number;
-  caseForm: {
-    open: boolean,
-    region: string,
-    type: string,
-    impressive: string,
-    overview: string,
-  },
-  setCaseForm: Dispatch<SetStateAction<{
-    open: boolean,
-    region: string,
-    type: string,
-    impressive: string,
-    overview: string,
-  }>>
+  caseForm: TCaseForm,
+  setCaseForm: Dispatch<SetStateAction<TCaseForm>>;
 }
 
 const Selector = ({text, options, type, caseForm, setCaseForm }: TSelector) => {

--- a/src/stories/molecules/selector/index.tsx
+++ b/src/stories/molecules/selector/index.tsx
@@ -1,12 +1,27 @@
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
-import { useState } from 'react';
+import { Dispatch, SetStateAction, useState } from 'react';
 
 type TSelector = {
   text: string;
   options: string[];
+  type: number;
+  caseForm: {
+    open: boolean,
+    region: string,
+    type: string,
+    impressive: string,
+    overview: string,
+  },
+  setCaseForm: Dispatch<SetStateAction<{
+    open: boolean,
+    region: string,
+    type: string,
+    impressive: string,
+    overview: string,
+  }>>
 }
 
-const Selector = ({text, options}: TSelector) => {
+const Selector = ({text, options, type, caseForm, setCaseForm }: TSelector) => {
 
   const [isOpen, setIsOpen] = useState(false);
   const [selectedOption, setSelectedOption] = useState<string>('');
@@ -17,6 +32,13 @@ const Selector = ({text, options}: TSelector) => {
 
   const handleOptionSelect = (option: string) => {
     setSelectedOption(option);
+    if (type === 0) {
+      setCaseForm({...caseForm, open: option==="공개"? true: false})
+    } else if (type === 1) {
+      setCaseForm({...caseForm, region: option})
+    } else if (type === 2) {
+      setCaseForm({...caseForm, type: option})
+    }
     setIsOpen(false);
   };
 
@@ -29,21 +51,20 @@ const Selector = ({text, options}: TSelector) => {
     <div className="flex flex-col gap-2">
       <div>{text}</div>
       <div className='relative'>
-        <select value={selectedOption} className="w-full max-w-193 rounded-12 border-2 border-superSubColor px-14 py-10 appearance-none" onClick={handleSelectClick} onChange={(e) => setSelectedOption(e.target.value)} >
-          <option value="">
+        <select className='w-193 rounded-12 border-2 border-superSubColor px-14 py-10 appearance-none' onClick={handleSelectClick} onChange={(e) => setSelectedOption(e.target.value)} >
+          <option>
             {selectedOption ? selectedOption : '옵션을 선택하세요'}
           </option>
         </select>
         <span className='absolute top-1/4 start-40 text-superSubColor cursor-pointer' onClick={handleToggle}><KeyboardArrowDownIcon /></span>
         
         {isOpen && (
-          <div className="absolute top-full left-0 z-10 w-full max-w-193 rounded-12 border-2 border-superSubColor mt-1">
-          
+          <div className="absolute top-full left-0 z-10 w-full max-w-193 rounded-12 border-2 border-superSubColor mt-1 bg-white p-3">
             {options.map((item, index) => (
               <option
                 key={`${item}+${index}`}
                 value={item}
-                className="px-10 py-6 cursor-pointer hover:bg-gray-200"
+                className="px-10 py-6 cursor-pointer hover:bg-gray-200 bg-white"
                 onClick={() => handleOptionSelect(item)}
               >
                 {item}
@@ -52,7 +73,6 @@ const Selector = ({text, options}: TSelector) => {
           </div>
         )}
       </div>
-      
     </div>
   )
 }

--- a/src/stories/molecules/textarea/index.stories.tsx
+++ b/src/stories/molecules/textarea/index.stories.tsx
@@ -1,0 +1,20 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import TextArea from '.';
+
+const meta: Meta<typeof TextArea> = {
+  title: 'molecules/TextArea',
+  component: TextArea,
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof TextArea>;
+
+export const Primary: Story = {
+  args: {
+    text: "인상 착의를 설명하세요.",
+    placeholder: "20대 중반~30대 초반 남자, 178 가량. 건장한 체격. 상의 흰색 와이셔츠, 검은색 모자를 눌러씀, 구두 착용",
+    rows: 4,
+    maxInput: 350,
+  },
+};

--- a/src/stories/molecules/textarea/index.tsx
+++ b/src/stories/molecules/textarea/index.tsx
@@ -1,0 +1,37 @@
+import { Dispatch, SetStateAction, useState } from "react";
+import { TCaseForm } from "../../pages/caseRegist/CaseRegistPage";
+
+type TTextArea = {
+  text: string;
+  placeholder: string;
+  rows: number;
+  maxInput: number;
+  type: number;
+  caseForm: TCaseForm,
+  setCaseForm: Dispatch<SetStateAction<TCaseForm>>;
+}
+
+const TextArea = ({text, rows, maxInput, placeholder, type, caseForm, setCaseForm}: TTextArea) => {
+  const [inputCount, setInputCount] = useState(0);
+
+const onTextareaHandler = (input: string) => {
+    setInputCount(
+      input.replace(/[\0-\x7f]|([0-\u07ff]|(.))/g, "$&$1$2").length
+    );
+    if (type === 0) {
+      setCaseForm({...caseForm, impressive: input})
+    } else if (type === 1) {
+      setCaseForm({...caseForm, overview: input})
+    }
+    
+  };
+  return (
+    <>
+      <div className="flex justify-between">{text} <span className="text-superSubColor font-semibold">({inputCount}/{maxInput})</span></div>
+      <textarea placeholder={placeholder} maxLength={maxInput} rows={rows} className="w-full rounded-12 border-2 border-superSubColor px-14 py-10 mt-8" onChange={(e) => onTextareaHandler(e.target.value)}>
+      </textarea>
+    </>
+  )
+}
+
+export default TextArea;

--- a/src/stories/organisms/signMember/index.stories.tsx
+++ b/src/stories/organisms/signMember/index.stories.tsx
@@ -12,8 +12,8 @@ type Story = StoryObj<typeof SignMember>;
 
 export const Primary: Story = {
   args: {
-    title: '목격자',
-    subtitle: '일반 시민, 참고인 권한',
+    title: '몽타주 전문가',
+    subtitle: '몽타주 제작 전문가',
     police: false
   },
 };     

--- a/src/stories/organisms/signMember/index.tsx
+++ b/src/stories/organisms/signMember/index.tsx
@@ -5,12 +5,13 @@ import VisibilityIcon from '@mui/icons-material/Visibility';
 type TSignMember = {
   title: string;
   subtitle: string;
-  police: boolean
+  police: boolean;
+  onClick: () => void;
 }
 
-const SignMember = ({title, subtitle, police}: TSignMember) => {
+const SignMember = ({title, subtitle, police, onClick}: TSignMember) => {
   return (
-    <div className="text-center border rounded-20 p-40 w-full max-w-350 h-460 gap-2">
+    <div className="text-center border rounded-20 p-40 w-full max-w-350 h-460 gap-2 bg-white" onClick={onClick}>
       <Title text={title} />
       <div className="text-grayColor text-15 mb-70">{subtitle}</div>
       {police? <LocalPoliceIcon style={{width: 120, height:120}} /> : <VisibilityIcon style={{width: 120, height:120}} />}

--- a/src/stories/organisms/signMember/index.tsx
+++ b/src/stories/organisms/signMember/index.tsx
@@ -11,7 +11,7 @@ type TSignMember = {
 
 const SignMember = ({title, subtitle, police, onClick}: TSignMember) => {
   return (
-    <div className="text-center border rounded-20 p-40 w-full max-w-350 h-460 gap-2 bg-white" onClick={onClick}>
+    <div className="text-center border rounded-20 p-40 w-full max-w-320 h-440 bg-white" onClick={onClick}>
       <Title text={title} />
       <div className="text-grayColor text-15 mb-70">{subtitle}</div>
       {police? <LocalPoliceIcon style={{width: 120, height:120}} /> : <DrawIcon style={{width: 120, height:120}} />}

--- a/src/stories/organisms/signMember/index.tsx
+++ b/src/stories/organisms/signMember/index.tsx
@@ -1,6 +1,6 @@
 import Title from "../../atoms/title";
 import LocalPoliceIcon from '@mui/icons-material/LocalPolice';
-import VisibilityIcon from '@mui/icons-material/Visibility';
+import DrawIcon from '@mui/icons-material/Draw';
 
 type TSignMember = {
   title: string;
@@ -14,7 +14,7 @@ const SignMember = ({title, subtitle, police, onClick}: TSignMember) => {
     <div className="text-center border rounded-20 p-40 w-full max-w-350 h-460 gap-2 bg-white" onClick={onClick}>
       <Title text={title} />
       <div className="text-grayColor text-15 mb-70">{subtitle}</div>
-      {police? <LocalPoliceIcon style={{width: 120, height:120}} /> : <VisibilityIcon style={{width: 120, height:120}} />}
+      {police? <LocalPoliceIcon style={{width: 120, height:120}} /> : <DrawIcon style={{width: 120, height:120}} />}
     </div>
   )
 }

--- a/src/stories/pages/caseDetail/CaseDetailPage.tsx
+++ b/src/stories/pages/caseDetail/CaseDetailPage.tsx
@@ -1,0 +1,34 @@
+import './styles.css'
+
+const CaseDetailPage = () => {
+  return (
+    <div className="flex justify-center">
+      <div className="bg-white  w-full max-w-748 h-full max-h-fit rounded-20 py-20 px-50 mt-30">
+        <div className="flex gap-8 mt-20">
+          <div className="montage"><div className='region'>서울</div></div>
+          <div>
+            <div className='text-mainColor font-semibold text-20'>인상착의</div>
+            <div className='mt-5 border-2 border-superSubColor w-full max-w-360 h-215 rounded-12 px-14 py-16'>
+              넌 잠에 드는 법도 모른 채 밤을 걷지
+              언제부터 넌 너를 속이고 밝게 웃지
+              아무도 너의 슬픔을 알아주지 않지
+              눈물을 감추기엔 네가 가여워서 못 버텨
+            </div>
+          </div>
+        </div>
+        <div>
+          <div className='text-mainColor font-semibold text-20 mt-20'>사건개요</div>
+          <div className='mt-5 border-2 border-superSubColor w-full h-140 rounded-12 px-14 py-16'>
+            넌 잠에 드는 법도 모른 채 밤을 걷지
+            언제부터 넌 너를 속이고 밝게 웃지
+            아무도 너의 슬픔을 알아주지 않지
+            눈물을 감추기엔 네가 가여워서 못 버텨
+          </div>
+        </div>
+        <div className="flex justify-end"><button className="text-white bg-mainColor px-35 py-10 rounded-16 my-20">수정하기</button></div>
+      </div>
+    </div>
+  )
+}
+
+export default CaseDetailPage;

--- a/src/stories/pages/caseDetail/styles.css
+++ b/src/stories/pages/caseDetail/styles.css
@@ -1,0 +1,21 @@
+.montage {
+  position: relative;
+  width: 250px;
+  height: 250px;
+  background-image: url('https://img.danawa.com/prod_img/500000/388/133/img/24133388_1.jpg?_v=20230728095239');
+  background-size: cover;
+  background-position: center; 
+  border: 2px solid #DBE2EF;
+  border-radius: 12px;
+}
+
+.region {
+  position: absolute;
+  right: 5px;
+  bottom: 5px;
+  color: #112D4E;
+  font-weight: 600;
+  background-color: #DBE2EF;
+  padding: 8px 20px;
+  border-radius: 18px;
+}

--- a/src/stories/pages/caseRegist/CaseRegistPage.tsx
+++ b/src/stories/pages/caseRegist/CaseRegistPage.tsx
@@ -1,0 +1,45 @@
+import { useState } from "react";
+import Title from "../../atoms/title";
+import Selector from "../../molecules/selector";
+import TextArea from "../../molecules/textarea";
+
+export type TCaseForm = { 
+  open: boolean,
+  region: string,
+  type: string,
+  impressive: string,
+  overview: string,
+}
+
+const CaseRegistPage = () => {
+
+  const [caseForm, setCaseForm] = useState<TCaseForm>({
+    open: false,
+    region: '',
+    type: '',
+    impressive: '',
+    overview: '',
+  })
+
+  return (
+    <div className="flex justify-center">
+      <div className="bg-white w-full max-w-748 h-full max-h-fit rounded-20 py-20 px-50 mt-30">
+        <div className="mt-20"><Title text="사건 등록" /></div>
+        <div className="mt-30"><Selector text="시민 공개범위를 선택하세요." options={["비공개","공개"]} type={0} caseForm={caseForm} setCaseForm={setCaseForm} /></div>
+        <div className="mt-20 flex gap-20">
+          <Selector text="사건 발생 지역을 선택하세요." options={["서울","인천","경기"]} type={1} caseForm={caseForm} setCaseForm={setCaseForm} />
+          <Selector text="범죄 종류를 선택하세요." options={["살인","성범죄","절도범죄","폭력범죄"]} type={2} caseForm={caseForm} setCaseForm={setCaseForm} />
+        </div>
+        <div className="mt-20">
+          <TextArea text="인상 착의를 설명해주세요." rows={3} placeholder="20대 중반~30대 초반 남자, 178 가량. 건장한 체격. 상의 흰색 와이셔츠, 검은색 모자를 눌러씀, 구두 착용" maxInput={200} type={0} caseForm={caseForm} setCaseForm={setCaseForm}  />
+        </div>
+        <div className="mt-20">
+          <TextArea text="사건 개요를 설명하세요." rows={5} placeholder="대전 서구 둔산동 00아파트에 거주하는 초등학생 여자 아이를 납치하여 피해자 주거지 옥상 기계실에 감금 후, 살해" maxInput={350} type={1} caseForm={caseForm} setCaseForm={setCaseForm}  />
+        </div>
+        <div className="flex justify-end"><button className="text-white bg-mainColor px-35 py-10 rounded-16 my-20">등록하기</button></div>
+      </div>
+    </div>
+  )
+}
+
+export default CaseRegistPage;

--- a/src/stories/pages/enterCode/EnterCodePage.tsx
+++ b/src/stories/pages/enterCode/EnterCodePage.tsx
@@ -1,0 +1,25 @@
+import ShortBtn from "../../atoms/shortBtn";
+import Title from "../../atoms/title";
+import Longfield from "../../molecules/longfield";
+
+
+const EnterCodePage = () => {
+
+  const handleCodeChange = () => {
+    return;
+  }
+
+  return(
+    <div className="flex justify-center mt-150">
+      <div className="bg-white text-center rounded-20 px-40 pt-50 pb-70 w-full max-w-600">
+        <Title text="범인 코드를 입력하세요." />
+        <div className="flex justify-center gap-4 mt-45">
+          <Longfield type="text" onChange={handleCodeChange} />
+          <span className="mt-6"><ShortBtn text="Enter" activate={true} disabled={false} /></span>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default EnterCodePage;

--- a/src/stories/pages/login/LoginPage.tsx
+++ b/src/stories/pages/login/LoginPage.tsx
@@ -32,7 +32,7 @@ const LoginPage = () => {
         <div className="mt-30"><Longfield label="이메일" type="text" placeholder="example@gmail.com" onChange={e => setForm({...form, email:e.target.value})} /></div>
         <div className="mt-10"><Longfield label="비밀번호" type="password" placeholder="대소문자 구분 없이 6자 이상, 특수문자 포함" onChange={e => setForm({...form, password:e.target.value})} /></div>
         <div className="mt-50"><LongBtn text="로그인" onClick={handleClick} activate={form.email && form.password? true: false} /></div>
-        <div className="mt-12 gap-2 text-14 text-center">회원이 아니신가요? <a href="/join" className="text-14 font-semibold">가입하기</a></div>
+        <div className="mt-12 gap-2 text-14 text-center">회원이 아니신가요? <a href="/member" className="text-14 font-semibold">가입하기</a></div>
       </form>
     </div>
   )

--- a/src/stories/pages/montagePublic/MontagePublicPage.tsx
+++ b/src/stories/pages/montagePublic/MontagePublicPage.tsx
@@ -11,7 +11,7 @@ const MontagePublicPage = () => {
           <div className="text-20 font-semibold text-white mt-30 mb-20">{montage.crimeCategory}</div>
           <div className="flex flex-wrap gap-20">
             {montage.criminals.map((info) => (
-              <InfoCard key={info.id} name={info.name} age={info.age} imgSrc={info.imgSrc} />
+              <InfoCard key={info.id} name={info.name} age={info.age} imgSrc={info.imgSrc} id={info.id} />
             ))}
           </div>
         </div>

--- a/src/stories/pages/my/MyPage.tsx
+++ b/src/stories/pages/my/MyPage.tsx
@@ -1,0 +1,8 @@
+
+const MyPage = () => {
+  return (
+    <div></div>
+  )
+}
+
+export default MyPage;

--- a/src/stories/pages/sign/SignMemberPage.tsx
+++ b/src/stories/pages/sign/SignMemberPage.tsx
@@ -1,0 +1,19 @@
+import { useNavigate } from "react-router-dom";
+import SignMember from "../../organisms/signMember";
+
+const SignMemberPage = () => {
+  const navigate = useNavigate();
+  const handleJoinClick = () => {
+    navigate('/join')
+  }
+  return(
+    <div className="justify-center items-center ">
+      <div className="flex justify-center mt-100 gap-8">
+      <SignMember title="경찰" subtitle="과학수사관리관, 수사국, 형사국" police={true} onClick={handleJoinClick} />
+      <SignMember title="목격자" subtitle="일반 시민, 참고인 권한" police={false} onClick={handleJoinClick} />
+      </div>
+    </div>
+  )
+}
+
+export default SignMemberPage;

--- a/src/stories/pages/sign/SignMemberPage.tsx
+++ b/src/stories/pages/sign/SignMemberPage.tsx
@@ -8,9 +8,9 @@ const SignMemberPage = () => {
   }
   return(
     <div className="justify-center items-center ">
-      <div className="flex justify-center mt-100 gap-8">
+      <div className="flex justify-center mt-100 gap-12">
       <SignMember title="경찰" subtitle="과학수사관리관, 수사국, 형사국" police={true} onClick={handleJoinClick} />
-      <SignMember title="목격자" subtitle="일반 시민, 참고인 권한" police={false} onClick={handleJoinClick} />
+      <SignMember title="몽타주 전문가" subtitle="몽타주 제작 전문가" police={false} onClick={handleJoinClick} />
       </div>
     </div>
   )

--- a/src/stories/template/common/MypageLayout.tsx
+++ b/src/stories/template/common/MypageLayout.tsx
@@ -1,0 +1,27 @@
+import Header from "../../molecules/header"
+import { Outlet } from "react-router-dom";
+
+const MypageLayout = () => {
+  return (
+    <div className="max-w-1440 min-h-screen h-full flex flex-col">
+      <Header />
+      <div className="flex flex-col flex-grow px-40 bg-mainColor pt-10 pb-50">
+        <div className="flex bg-white w-full h-full min-h-600 px-50 mt-30 rounded-20">
+          <div className="grid grid-cols-5 py-20">
+            <div className="col-span-2 mt-35">
+              <div className="text-20 font-semibold">몽타주 전문가(홍길동)</div>
+              <div className="h-2 bg-superSubColor w-full mt-5"></div>
+              <div className="mt-15">관리사건</div>
+            </div>
+          <div className="h-full min-h-580 w-2 bg-superSubColor ml-20"></div>
+            <div className="col-span-3">
+              <Outlet />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default MypageLayout;

--- a/src/types/case/caseList.ts
+++ b/src/types/case/caseList.ts
@@ -1,0 +1,5 @@
+export type caseList = {
+  no: string;
+  public: boolean;
+  montage: string;
+}


### PR DESCRIPTION
### PR Type

- [x] 기능 개발 (Feature)
- [x] 화면 작업 (Style, CSS)

## 작업 내용

- #37 
- 마이페이지 레이아웃
- 마이페이지에서 쓰일 사건 관리 테이블 컴포넌트

## Before

## After

- 테이블 컴포넌트
<img width="809" alt="스크린샷 2023-11-21 오후 6 34 40" src="https://github.com/Catch-You/CatchYou-Frontend/assets/69382168/ea708a3d-8909-414b-8dc5-a611be04656e">

- 마이페이지 레이아웃
<img width="1185" alt="스크린샷 2023-11-21 오후 6 46 12" src="https://github.com/Catch-You/CatchYou-Frontend/assets/69382168/1353a8e4-7f07-44f5-b35e-80aa1b66fc80">

## 참고 사항, 첨부 자료 등

- tailwindcss 로 table의 borderRadius 적용
https://velog.io/@rkio/Tailwind-table-%ED%83%9C%EA%B7%B8-%ED%85%8C%EB%91%90%EB%A6%AC%EB%A5%BC-%EC%84%A4%EC%A0%95%ED%95%A0-%EB%95%8Cft.-%EB%91%A5%EA%B8%80%EA%B2%8C